### PR TITLE
ethers bug: add peer dependency, move core dependency to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "async-mutex": "^0.4.0",
     "axios": "^1.3.4",
-    "ethers": "^6.5.1",
     "eventsource": "^2.0.2"
   },
   "devDependencies": {
@@ -20,9 +19,13 @@
     "dotenv": "^16.0.3",
     "eslint": "^8.36.0",
     "eslint-plugin-tsdoc": "^0.2.17",
+    "ethers": "^6.5.1",
     "release-it": "^15.8.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
+  },
+  "peerDependencies": {
+    "ethers": "^6.5.1"
   },
   "scripts": {
     "build": "tsc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,9 +1200,9 @@ esutils@^2.0.2:
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 ethers@^6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.5.1.tgz#7beeeea2156dc4227da1176cb164007018b85c63"
-  integrity sha512-jDpCnUGcyn39hnRUEtrulDZOtJcIPEz4Whccl3N9qhwdLsn1ELuDM9TgGgGJq6ph0p8/Uri+Wezmo/r69E+xkA==
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.6.2.tgz#0b6131b5fa291fec69b7ae379cb6bb2405c505a7"
+  integrity sha512-vyWfVAj2g7xeZIivOqlbpt7PbS2MzvJkKgsncgn4A/1xZr8Q3BznBmEBRQyPXKCgHmX4PzRQLpnYG7jl/yutMg==
   dependencies:
     "@adraffy/ens-normalize" "1.9.2"
     "@noble/hashes" "1.1.2"


### PR DESCRIPTION
- fixes bug where invalid ethers version is not detected. Enforces peer dependency of ethers^6.5.1
- locked ethers dependency is 6.6.2